### PR TITLE
Convert epsilon to mpf on constructing EpsilonRegion

### DIFF
--- a/pygridsynth/gridsynth.py
+++ b/pygridsynth/gridsynth.py
@@ -13,6 +13,7 @@ from .synthesis_of_cliffordT import decompose_domega_unitary
 
 class EpsilonRegion(ConvexSet):
     def __init__(self, theta, epsilon):
+        epsilon = mpmath.mpf(epsilon)
         self._theta = theta
         self._epsilon = epsilon
         self._d = 1 - epsilon ** 2 / 2


### PR DESCRIPTION
This allows the caller of the functions gridsynth and gridsynth_gates to pass epsilon of type `float`, rather than requiring an mpf.

One expects that epsilon may be a `float`. This will help avoid bugs due to this expectation.