### PR TITLE
Pass timeout CLI options to synthesis routines

### DIFF
--- a/pygridsynth/__main__.py
+++ b/pygridsynth/__main__.py
@@ -23,6 +23,8 @@ def main():
     epsilon = mpmath.mpmathify(args.epsilon)
 
     gates = gridsynth_gates(theta=theta, epsilon=epsilon,
+                            factoring_timeout=args.ftimeout,
+                            diophantine_timeout=args.dtimeout,
                             verbose=args.verbose, measure_time=args.time,
                             show_graph=args.showgraph)
     print(gates)


### PR DESCRIPTION
The command line options that allow setting factoring timeout and Diophantine solution timeout were ignored. This commit passes them to the synthesis routines.