### PR TITLE
Allow installing an executable script pygridsynth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,35 @@ Or, to install from source:
 pip install git+https://github.com/quantum-programming/pygridsynth.git
 ```
 
+### Install executable
+
+You can optionally install an executable script called `pygridsynth` with
+
+```bash
+pip install .
+```
+
+Or, to install in development (editable) mode
+
+```bash
+pip install -e .
+```
+
+The versions of `pygridsynth` available on pypi do not yet support
+installing an executable in this way.
+
+Once you have installed this executable, you can use `pygridsynth` like this
+
+```sh
+shell> pygridsynth <theta> <epsilon> [options]
+```
+
+or `pygridsynth --help` for brief information on calling the script.
+
 ## Usage
 
-`pygridsynth` can be used as a command-line tool.
+`pygridsynth` can be used as a command-line tool even if you have not installed the
+executable.
 
 ### Command-Line Example
 

--- a/pygridsynth/__init__.py
+++ b/pygridsynth/__init__.py
@@ -1,1 +1,3 @@
 from .gridsynth import *
+
+from .__main__ import main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup, find_packages
+
+setup(
+    entry_points={
+        'console_scripts': [
+            'pygridsynth = pygridsynth.__main__:main',
+        ],
+    }
+)


### PR DESCRIPTION
For example, with
pip install .
or
pip install -e .