### PR TITLE
Refine help messages and improve loop control

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+        args: ["--profile", "black"]
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -66,13 +66,12 @@ python -m pygridsynth <theta> <epsilon> [options]
 
 ### Options
 
-- `--dps`: Sets the working precision of the calculation. If `--dps` is not given, then the working precision will
-           be calculated from `epsilon`.
-- `--dtimeout`, `-dt`: Sets the timeout for solving diophantine equations in milliseconds.
-- `--ftimeout`, `-ft`: Sets the timeout for factorization in milliseconds.
-- `--dloop`, `-dl`: Sets the maximum loop count for the diophantine algorithm (default: `2000`).
-- `--floop`, `-fl`: Sets the maximum loop count for the factoring algorithm (default: `500`).
-- `--seed`: Sets the random seed for deterministic results (default: `0`).
+- `--dps`: Sets the working precision of the calculation. If not specified, the working precision will be calculated from `epsilon`.
+- `--dtimeout`, `-dt`: Maximum milliseconds allowed for a single Diophantine equation solving.
+- `--ftimeout`, `-ft`: Maximum milliseconds allowed for a single integer factoring attempt.
+- `--dloop`, `-dl`: Maximum number of failed integer factoring attempts allowed during Diophantine equation solving　(default: `2000`).
+- `--floop`, `-fl`: Maximum number of failed integer factoring attempts allowed during the factoring process (default: `500`).
+- `--seed`: Random seed for deterministic results. (default: `0`)
 - `--verbose`, `-v`: Enables detailed output.
 - `--time`, `-t`: Measures the execution time.
 - `--showgraph`, `-g`: Displays the decomposition result as a graph.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ python -m pygridsynth <theta> <epsilon> [options]
 - `--ftimeout`, `-ft`: Maximum milliseconds allowed for a single integer factoring attempt.
 - `--dloop`, `-dl`: Maximum number of failed integer factoring attempts allowed during Diophantine equation solving (default: `2000`).
 - `--floop`, `-fl`: Maximum number of failed integer factoring attempts allowed during the factoring process (default: `500`).
-- `--seed`: Random seed for deterministic results. (default: `0`)
+- `--seed`: Random seed for deterministic results.(default: `0`)
 - `--verbose`, `-v`: Enables detailed output.
 - `--time`, `-t`: Measures the execution time.
 - `--showgraph`, `-g`: Displays the decomposition result as a graph.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python -m pygridsynth <theta> <epsilon> [options]
 - `--dps`: Sets the working precision of the calculation. If not specified, the working precision will be calculated from `epsilon`.
 - `--dtimeout`, `-dt`: Maximum milliseconds allowed for a single Diophantine equation solving.
 - `--ftimeout`, `-ft`: Maximum milliseconds allowed for a single integer factoring attempt.
-- `--dloop`, `-dl`: Maximum number of failed integer factoring attempts allowed during Diophantine equation solving　(default: `2000`).
+- `--dloop`, `-dl`: Maximum number of failed integer factoring attempts allowed during Diophantine equation solving (default: `2000`).
 - `--floop`, `-fl`: Maximum number of failed integer factoring attempts allowed during the factoring process (default: `500`).
 - `--seed`: Random seed for deterministic results. (default: `0`)
 - `--verbose`, `-v`: Enables detailed output.

--- a/pygridsynth/cli.py
+++ b/pygridsynth/cli.py
@@ -7,10 +7,16 @@ from .gridsynth import gridsynth_gates
 from .loop_controller import LoopController
 
 helps = {
-    "dt": "Diophantine algorithm timeout in milliseconds",
-    "ft": "Factoring algorithm timeout in milliseconds",
-    "dl": "Diophantine algorithm max loop count",
-    "fl": "Factoring algorithm max loop count",
+    "dt": "Maximum milliseconds allowed for a single Diophantine equation solving",
+    "ft": "Maximum milliseconds allowed for a single integer factoring attempt",
+    "dl": (
+        "Maximum number of failed integer factoring attempts "
+        "allowed during Diophantine equation solving"
+    ),
+    "fl": (
+        "Maximum number of failed integer factoring attempts "
+        "allowed during the factoring process"
+    ),
     "seed": "Random seed for deterministic results",
 }
 

--- a/pygridsynth/diophantine.py
+++ b/pygridsynth/diophantine.py
@@ -26,7 +26,7 @@ def _find_factor(n, loop_controller: LoopController, M=128):
     L = int(10 ** (len(str(n)) / 4) * 1.1774 + 10)
 
     loop_controller.start_factoring()
-    while loop_controller.check_factoring_continue():
+    while True:
         x = y + n
         while k < r:
             q = 1
@@ -47,7 +47,7 @@ def _find_factor(n, loop_controller: LoopController, M=128):
                         if g != 1:
                             break
                 return None if g == n else g
-            if k >= L:
+            if k >= L and not loop_controller.check_factoring_continue():
                 return None
         r <<= 1
 


### PR DESCRIPTION
このコミットの精緻化にあたる内容です。

https://github.com/quantum-programming/pygridsynth/commit/18839adda1a1c42750adea6b5dc8743c21f86bea

作業していて気付いた点として、そもそも_find_factor関数はテストの範囲内だと呼ばれてすらいないので、このオプションに対するテストとして不十分です。新しくLoopControllerで指定しているループ回数が、元々の秒数指定に対して本当に等価な振る舞いをしているか確かめるうえでも、テストを追加した方が良いかもしれません。

このPRは全く急ぎの内容ではないので、お時間があるときにゆっくりご確認いただくのがいいと思います。