### PR TITLE
fix the args of gridsynth_gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ python -m pygridsynth <theta> <epsilon> [options]
 - `--dps`: Sets the working precision of the calculation. If not specified, the working precision will be calculated from `epsilon`.
 - `--dtimeout`, `-dt`: Maximum milliseconds allowed for a single Diophantine equation solving.
 - `--ftimeout`, `-ft`: Maximum milliseconds allowed for a single integer factoring attempt.
-- `--dloop`, `-dl`: Maximum number of failed integer factoring attempts allowed during Diophantine equation solving (default: `2000`).
-- `--floop`, `-fl`: Maximum number of failed integer factoring attempts allowed during the factoring process (default: `500`).
+- `--dloop`, `-dl`: Maximum number of failed integer factoring attempts allowed during Diophantine equation solving (default: `10`).
+- `--floop`, `-fl`: Maximum number of failed integer factoring attempts allowed during the factoring process (default: `10`).
 - `--seed`: Random seed for deterministic results.(default: `0`)
 - `--verbose`, `-v`: Enables detailed output.
 - `--time`, `-t`: Measures the execution time.

--- a/pygridsynth/cli.py
+++ b/pygridsynth/cli.py
@@ -1,8 +1,6 @@
 import argparse
 
-from .diophantine import set_random_seed
 from .gridsynth import gridsynth_gates
-from .loop_controller import LoopController
 
 helps = {
     "dt": "Maximum milliseconds allowed for a single Diophantine equation solving",
@@ -27,28 +25,23 @@ def main():
     parser.add_argument("--dps", type=int, default=None)
     parser.add_argument("--dtimeout", "-dt", type=float, default=None, help=helps["dt"])
     parser.add_argument("--ftimeout", "-ft", type=float, default=None, help=helps["ft"])
-    parser.add_argument("--dloop", "-dl", type=int, default=2000, help=helps["dl"])
-    parser.add_argument("--floop", "-fl", type=int, default=500, help=helps["fl"])
+    parser.add_argument("--dloop", "-dl", type=int, default=10, help=helps["dl"])
+    parser.add_argument("--floop", "-fl", type=int, default=10, help=helps["fl"])
     parser.add_argument("--seed", type=int, default=0, help=helps["seed"])
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument("--time", "-t", action="store_true")
     parser.add_argument("--showgraph", "-g", action="store_true")
     args = parser.parse_args()
 
-    # Set random seed for deterministic results
-    set_random_seed(args.seed)
-
-    loop_controller = LoopController(
-        dloop=args.dloop,
-        floop=args.floop,
-        dtimeout=args.dtimeout,
-        ftimeout=args.ftimeout,
-    )
     gates = gridsynth_gates(
         theta=args.theta,
         epsilon=args.epsilon,
         dps=args.dps,
-        loop_controller=loop_controller,
+        dtimeout=args.dtimeout,
+        ftimeout=args.ftimeout,
+        dloop=args.dloop,
+        floop=args.floop,
+        seed=args.seed,
         verbose=args.verbose,
         measure_time=args.time,
         show_graph=args.showgraph,

--- a/pygridsynth/diophantine.py
+++ b/pygridsynth/diophantine.py
@@ -47,7 +47,7 @@ def _find_factor(n, loop_controller: LoopController, M=128):
                         if g != 1:
                             break
                 return None if g == n else g
-            if k >= L and not loop_controller.check_factoring_continue():
+            if k >= L or not loop_controller.check_factoring_continue():
                 return None
         r <<= 1
 

--- a/pygridsynth/gridsynth.py
+++ b/pygridsynth/gridsynth.py
@@ -3,7 +3,7 @@ import warnings
 
 import mpmath
 
-from .diophantine import NO_SOLUTION, diophantine_dyadic
+from .diophantine import NO_SOLUTION, diophantine_dyadic, set_random_seed
 from .loop_controller import LoopController
 from .mymath import solve_quadratic, sqrt
 from .quantum_gate import Rz
@@ -286,12 +286,16 @@ def gridsynth_circuit(
 def gridsynth_gates(
     theta,
     epsilon,
-    decompose_phase_gate=True,
     dps=None,
-    loop_controller=None,
+    dtimeout=None,
+    ftimeout=None,
+    dloop=10,
+    floop=10,
+    seed=0,
     verbose=False,
     measure_time=False,
     show_graph=False,
+    decompose_phase_gate=True,
 ):
     if isinstance(theta, float):
         warnings.warn(
@@ -316,6 +320,12 @@ def gridsynth_gates(
             UserWarning,
             stacklevel=2,
         )
+
+    set_random_seed(seed)
+
+    loop_controller = LoopController(
+        dloop=dloop, floop=floop, dtimeout=dtimeout, ftimeout=ftimeout
+    )
 
     if dps is None:
         dps = _dps_for_epsilon(epsilon)

--- a/pygridsynth/loop_controller.py
+++ b/pygridsynth/loop_controller.py
@@ -6,8 +6,8 @@ from typing import Optional
 class LoopController:
     def __init__(
         self,
-        dloop: int = 2000,
-        floop: int = 500,
+        dloop: int = 10,
+        floop: int = 10,
         dtimeout: Optional[float] = None,
         ftimeout: Optional[float] = None,
     ):


### PR DESCRIPTION
Changes are as follows:
1. Made it possible to specify floop and dloop directly from gridsynth_gates without going through LoopController.
2. Changed the default values of these arguments.
3. Made it possible to specify the seed in gridsynth_gates as well.

Points to confirm:
1. Please check if the default values of dloop and floop are appropriate.
2. Should we also add the boolean argument decompose_phase_gate to the CLI?